### PR TITLE
Update to Cursive version 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ categories = ["command-line-interface", "gui"]
 license = "MIT/Apache-2.0"
 
 [dependencies]
-cursive = "0.5"
+cursive = "0.6"
 
 [features]
 default = ["ncurses-backend"]


### PR DESCRIPTION
Currently Cursive is at version 0.6 so it is natural for cursive_tree_view to use that version