### PR TITLE
Support turning off ncurses support in cursive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 debug_stub_derive = "0.3.0"
-cursive = "0.7"
+
+[dependencies.cursive]
+version = "0.7"
+default-features = false
 
 [features]
 default = ["ncurses-backend"]


### PR DESCRIPTION
The cursive crate turns on ncurses support by default. When we depend on it without setting `default-features = false`, we force this support to always be turned on without giving downstream users the ability to turn it off.

This commit disables the default features in the dependency, but **our** default features still turn on ncurses support.