### PR TITLE
Bump cursive version and simplify backend handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 debug_stub_derive = "0.3.0"
-cursive = { version = "0.10", default-features = false }
+cursive = { version = "0.12", default-features = false }
 
-[features]
-default = ["ncurses-backend"]
-ncurses-backend = ["cursive/ncurses-backend"]
-pancurses-backend = ["cursive/pancurses-backend"]
-termion-backend = ["cursive/termion-backend"]
-blt-backend = ["cursive/blt-backend"]
-
+[dev-dependencies]
+cursive = "0.12"

--- a/README.md
+++ b/README.md
@@ -27,23 +27,6 @@ and this to your crate root:
 extern crate cursive_tree_view;
 ```
 
-### Different backends
-
-If you are using `cursive` with a different backend, you'll need to *forward*
-the identical features to your `cursive_tree_view` dependency:
-
-```toml
-[dependencies.cursive]
-version = "0.10"
-default-features = false
-features = ["blt-backend"]
-
-[dependencies.cursive_tree_view]
-version = "0.3"
-default-features = false
-features = ["blt-backend"]
-```
-
 ## License
 
 Licensed under either of


### PR DESCRIPTION
For the library itself the cursive backend doesn't matter,
those features can be safely removed. At least one backend
is necessary for the examples to work, re-enabling the default
features of cursive in dev-dependencies solve this.

This is a breaking change, bumping version to 0.4 will be necessary.