### PR TITLE
Replace cursive dependency with cursive_core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT/Apache-2.0"
 
 [dependencies]
 debug_stub_derive = "0.3.0"
-cursive = { version = "0.14", default-features = false }
+cursive_core = "0.1"
 
 [dev-dependencies]
 cursive = "0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 )]
 
 // Crate Dependencies ---------------------------------------------------------
-extern crate cursive;
+extern crate cursive_core;
 #[macro_use]
 extern crate debug_stub_derive;
 
@@ -20,13 +20,13 @@ use std::fmt::{Debug, Display};
 use std::rc::Rc;
 
 // External Dependencies ------------------------------------------------------
-use cursive::direction::Direction;
-use cursive::event::{Callback, Event, EventResult, Key};
-use cursive::theme::ColorStyle;
-use cursive::vec::Vec2;
-use cursive::view::{ScrollBase, View};
-use cursive::With;
-use cursive::{Cursive, Printer};
+use cursive_core::direction::Direction;
+use cursive_core::event::{Callback, Event, EventResult, Key};
+use cursive_core::theme::ColorStyle;
+use cursive_core::vec::Vec2;
+use cursive_core::view::{ScrollBase, View};
+use cursive_core::With;
+use cursive_core::{Cursive, Printer};
 
 // Internal Dependencies ------------------------------------------------------
 mod tree_list;


### PR DESCRIPTION
Currently, this crate depends on an older cursive version (0.14).  This patch replaces the cursive dependency with cursive_core 0.1.  This makes the crate compatible with never cursive versions and removes unnecessary transitive dependencies.